### PR TITLE
Implement Admin Mode: restrict registration/unregistration to teachers with authentication

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,13 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, status
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -77,6 +79,21 @@ activities = {
     }
 }
 
+security = HTTPBasic()
+
+def verify_teacher(credentials: HTTPBasicCredentials = Depends(security)):
+    """Verify teacher credentials from teachers.json"""
+    teachers_path = os.path.join(Path(__file__).parent, "teachers.json")
+    with open(teachers_path) as f:
+        teachers = json.load(f)["teachers"]
+    for teacher in teachers:
+        if credentials.username == teacher["username"] and credentials.password == teacher["password"]:
+            return True
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Invalid teacher credentials",
+        headers={"WWW-Authenticate": "Basic"}
+    )
 
 @app.get("/")
 def root():
@@ -89,44 +106,24 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
+def signup_for_activity(activity_name: str, email: str, authorized: bool = Depends(verify_teacher)):
+    """Sign up a student for an activity (teacher only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is not already signed up
     if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
+        raise HTTPException(status_code=400, detail="Student is already signed up")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+def unregister_from_activity(activity_name: str, email: str, authorized: bool = Depends(verify_teacher)):
+    """Unregister a student from an activity (teacher only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    {"username": "teacher1", "password": "pass123"},
+    {"username": "teacher2", "password": "pass456"}
+  ]
+}


### PR DESCRIPTION
This PR adds Admin Mode to the activities API:
- Only teachers (with credentials in teachers.json) can register or unregister students for activities.
- Adds HTTP Basic authentication for these endpoints.
- Credentials are checked from src/teachers.json.

Closes #5.